### PR TITLE
style(web): reformat tsconfig.json with biome

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,55 +1,38 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "target": "ES2023",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    },
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "lib": [
-      "ES2023",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "allowJs": true,
-    "noEmit": true
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    ".next"
-  ]
+	"compilerOptions": {
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noFallthroughCasesInSwitch": true,
+		"forceConsistentCasingInFileNames": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"target": "ES2023",
+		"outDir": "./dist",
+		"declaration": true,
+		"sourceMap": true,
+		"rootDir": ".",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"lib": ["ES2023", "DOM", "DOM.Iterable"],
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"allowJs": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*.ts", "src/**/*.tsx", "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules", "dist", ".next"]
 }


### PR DESCRIPTION
## 背景
b094d79 (2026-07-07) が Next.js 再生成の tsconfig.json（2スペース indent）をコミットし、biome の tab フォーマッタに違反。CI の lint-and-test-web (`biome check .`) は PR を main へマージした結果でテストするため、**全 dependabot PR (#21, #23, #26 等) の biome gate が失敗**していた（#21/#22/#26 の緑CIは4月実行で stale）。

## 変更
`biome format` で tsconfig.json を再整形。フォーマットのみ（2スペース→タブ、配列の1行化）で意味的変更なし。

## 効果
- 全オープン PR の `biome check .` gate を解除

## 補足
Next.js が tsconfig を再生成すると2スペースに戻る可能性がある（biome との恒常的緊張）。将来的に biome の JSON overrides か ignore 検討を推奨（本PRスコープ外）。